### PR TITLE
Update install_portia.sh

### DIFF
--- a/install_portia.sh
+++ b/install_portia.sh
@@ -11,6 +11,13 @@
 #Also I know my coding skills suck ok genius.. :)
 
 cd
+CAN_I_RUN_SUDO=$(sudo -n uptime 2>&1|grep "load"|wc -l)
+if [ ${CAN_I_RUN_SUDO} -gt 0 ]
+then
+echo "You can run the Sudo Command"
+else
+echo "You cannot run the Sudo command"
+fi
 clear;
 echo "Starting updates first...."
 sudo aptitude update && aptitude install curl git git-core python-pip python-dev toilet libxml2-dev libxslt1-dev libffi-dev libssl-dev && toilet -f mono12 -t --gay Updates Done && aptitude upgrade && toilet -f mono12 -t --gay Upgrades Done && aptitude dist-upgrade && toilet -f mono12 -t --gay Distro Upgraded


### PR DESCRIPTION
TMLutas wrote:

Turnkey Linux LAPP virtual machine does not include sudo out of the box. The script does not work as intended when that happens.

Suggestion, add in something like the following so the script informatively fails

CAN_I_RUN_SUDO=$(sudo -n uptime 2>&1|grep "load"|wc -l)
if [ ${CAN_I_RUN_SUDO} -gt 0 ]
then
echo "I can run the sudo command"
else
echo "I can't run the Sudo command"
fi

code pulled from:
http://superuser.com/questions/195781/sudo-is-there-a-command-to-check-if-i-have-sudo-and-or-how-much-time-is-left
